### PR TITLE
Bug: Subject blacklist (for commit) used for body

### DIFF
--- a/src/Hook/Message/Rule/Blacklist.php
+++ b/src/Hook/Message/Rule/Blacklist.php
@@ -110,7 +110,7 @@ class Blacklist extends Base
      */
     protected function isBodyValid(CommitMessage $msg)
     {
-        return !$this->containsBlacklistedWord($this->blacklist['subject'], $msg->getBody());
+        return !$this->containsBlacklistedWord($this->blacklist['body'], $msg->getBody());
     }
 
     /**


### PR DESCRIPTION
For the body blacklist check, the subject blacklist is used - while the body blacklist is never used because of this bug.

I stumbled on this problem when I tried to commit with the usage of "created" in the message body, which lead to an incorrect "Execution failed: Subject should be written in imperative mood, Invalid use of 'created'" error.