### PR TITLE
Print the commit message on BEAMS rules failure

### DIFF
--- a/src/Exception/ActionFailed.php
+++ b/src/Exception/ActionFailed.php
@@ -29,4 +29,15 @@ class ActionFailed extends \Exception
     {
         return new self($msg);
     }
+
+    /**
+     * Create a new exception based on a previous exception.
+     *
+     * @param  \SebastianFeldmann\CaptainHook\Exception\ActionFailed $exception
+     * @return \SebastianFeldmann\CaptainHook\Exception\ActionFailed
+     */
+    public static function fromPrevious(ActionFailed $exception)
+    {
+        return new self($exception->getMessage(), $exception->getCode(), $exception);
+    }
 }

--- a/src/Hook/Message/Action/Beams.php
+++ b/src/Hook/Message/Action/Beams.php
@@ -11,6 +11,7 @@ namespace SebastianFeldmann\CaptainHook\Hook\Message\Action;
 
 use SebastianFeldmann\CaptainHook\Config;
 use SebastianFeldmann\CaptainHook\Console\IO;
+use SebastianFeldmann\CaptainHook\Exception\ActionFailed;
 use SebastianFeldmann\CaptainHook\Hook\Message\Rule;
 use SebastianFeldmann\CaptainHook\Hook\Message\RuleBook;
 use SebastianFeldmann\Git\Repository;
@@ -49,6 +50,19 @@ class Beams extends Book
             ]
         );
 
-        $this->validate($book, $repository);
+        try {
+            $this->validate($book, $repository);
+        } catch (ActionFailed $exception) {
+            $io->writeError(
+                [
+                    "Commit message does not match style",
+                    "",
+                    "Message was:",
+                ]
+            );
+            $io->writeError($repository->getCommitMsg()->getBodyLines());
+
+            throw ActionFailed::fromPrevious($exception);
+        }
     }
 }


### PR DESCRIPTION
There's nothing more frustrating than writing a beautiful commit
message, then have having one stray too long line, or extra full stop
cause you to loose it all when the commit message linter triggers.

This change will allow the user to copy their commit message from the
terminal on failure, saving a whole bunch of frustration.