### PR TITLE
Set comment character based on users config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ext-json": "*",
     "ext-spl": "*",
     "sebastianfeldmann/cli": "^1.0.0",
-    "sebastianfeldmann/git": "^1.0.0",
+    "sebastianfeldmann/git": "^1.0.4",
     "symfony/console": ">=2.7 <4.0"
   },
   "require-dev": {

--- a/src/Console/Command/Hook/CommitMsg.php
+++ b/src/Console/Command/Hook/CommitMsg.php
@@ -52,6 +52,9 @@ class CommitMsg extends Hook
      */
     protected function setup(InputInterface $input, OutputInterface $output, Config $config, Git\Repository $repository)
     {
-        $repository->setCommitMsg(Git\CommitMessage::createFromFile($input->getFirstArgument()));
+        $gitConfig = $repository->getConfigOperator();
+        $commentCharacter = $gitConfig->has('core.commentchar') ? $gitConfig->get('core.commentchar') : '#';
+
+        $repository->setCommitMsg(Git\CommitMessage::createFromFile($input->getFirstArgument(), $commentCharacter));
     }
 }


### PR DESCRIPTION
For commit message hooks this will set the comment character based on
what the user has had set in their git config settings. This means that
if a user wants to be able, for example put a pull request ID (#123 for
example) at the start of their commit message, they can.