### PR TITLE
Add messages to regex action

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require-dev": {
     "composer/composer": "~1",
-    "phpunit/phpunit": "^7.1"
+    "phpunit/phpunit": "^6.5"
   },
   "bin": [
     "captainhook"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "symfony/console": ">=2.7"
   },
   "require-dev": {
-    "composer/composer": "~1"
+    "composer/composer": "~1",
+    "phpunit/phpunit": "^7.1"
   },
   "bin": [
     "captainhook"

--- a/tests/CaptainHook/Hook/Message/Action/RegexTest.php
+++ b/tests/CaptainHook/Hook/Message/Action/RegexTest.php
@@ -44,14 +44,20 @@ class RegexTest extends \PHPUnit\Framework\TestCase
      */
     public function testExecute()
     {
-        $options = ['regex' => '#.*#'];
-        $io      = new NullIO();
+        $successMessage = 'Regex matched';
+        $io = $this->createPartialMock(NullIO::class, ['write']);
+        $io->expects($this->once())->method('write')->with($successMessage);
+        /** @var NullIO $io */
+
         $config  = new Config(CH_PATH_FILES . '/captainhook.json');
         $repo    = new Repository($this->repo->getPath());
         $action  = new Config\Action(
             'php',
             '\\SebastianFeldmann\\CaptainHook\\Hook\\Message\\Action\\RegexCheck',
-            $options
+            [
+                'regex' => '#.*#',
+                'success' => $successMessage
+            ]
         );
         $repo->setCommitMsg(new CommitMessage('Foo bar baz'));
 
@@ -81,6 +87,7 @@ class RegexTest extends \PHPUnit\Framework\TestCase
      * Tests RegexCheck::execute
      *
      * @expectedException \Exception
+     * @expectedExceptionMessage No match for #FooBarBaz#
      */
     public function testExecuteNoMatch()
     {
@@ -89,7 +96,10 @@ class RegexTest extends \PHPUnit\Framework\TestCase
         $action = new Config\Action(
             'php',
             '\\SebastianFeldmann\\CaptainHook\\Hook\\Message\\Rulebook',
-            ['regex' => '#FooBarBaz#']
+            [
+                'regex' => '#FooBarBaz#',
+                'error' => 'No match for %s'
+            ]
         );
         $repo   = new Repository($this->repo->getPath());
         $repo->setCommitMsg(new CommitMessage('Foo bar baz'));

--- a/tests/CaptainHook/Hook/Message/Action/RegexTest.php
+++ b/tests/CaptainHook/Hook/Message/Action/RegexTest.php
@@ -53,7 +53,7 @@ class RegexTest extends \PHPUnit\Framework\TestCase
         $repo    = new Repository($this->repo->getPath());
         $action  = new Config\Action(
             'php',
-            '\\SebastianFeldmann\\CaptainHook\\Hook\\Message\\Action\\RegexCheck',
+            '\\SebastianFeldmann\\CaptainHook\\Hook\\Message\\Action\\Regex',
             [
                 'regex' => '#.*#',
                 'success' => $successMessage


### PR DESCRIPTION
Hi!

While using the RegEx action i missed the possibility to add better messages than just "Commit message did not match regex: #FoBar#" in the options.
The options "success" and "error" are purely optional and by using the "%s" operator in both of them, you can place the used regex anywhere you want.

Cheers!
Ben